### PR TITLE
TRADE_BASE_URLの修正とメソッドの追加

### DIFF
--- a/Zaif.php
+++ b/Zaif.php
@@ -56,6 +56,8 @@ class Zaif {
 			case 'trade' :
 			case 'cancel_order' :
 			case 'withdraw' :
+			case 'deposit_history' :
+			case 'withdraw_history' :
 				break;
 			default:
 				throw new Exception('Argument has not been set.');

--- a/Zaif.php
+++ b/Zaif.php
@@ -5,7 +5,7 @@ use WebSocket\Client;
 class Zaif {
 
 	const PUBLIC_BASE_URL = "https://api.zaif.jp/api/1";
-	const TRADE_BASE_URL = "https://zaif.jp/tapi";
+	const TRADE_BASE_URL = "https://api.zaif.jp/tapi";
 	const STREAMING_BASE_URL = "ws://api.zaif.jp:8888/stream";
 
 	private $key;


### PR DESCRIPTION
TRADE_BASE_URLですが、公式には https://api.zaif.jp/tapi となっています。
etwingsからの名残で https://zaif.jp/tapi でも動作するのですが、webサーバーのロードバランサー経由でapiサーバーに転送されるため、レスポンスが遅くなることがあるため、修正をおねがいします。

また、新しいメソッド（deposit_historyとwithdraw_history）もよろしくおねがいします。
