### PR TITLE
新規エンドポイント・信用取引・テストなどの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 一部機能を除けば、Windowsでも動くと思いますが、Linuxでの動作を想定しています。
 
+## 動作環境
+- PHP7.2以降での動作を想定しています
+
 ## 事前に必要な物
 - cURL
 
@@ -35,10 +38,10 @@ JSONがデコードされた状態で値が帰ってきます。
 Public APIを使うのにAPI Keyを発行する必要はありません。
 ```php
 //BTC_JPYの価格を取得する
-$price = Zaif::pub("last_price","btc_jpy");
+$price = Zaif::pub(PublicApiEndpoint::LAST_PRICE,"btc_jpy");
 
 //MONA_JPYの板情報を取得する
-$depth = Zaif::pub("depth","mona_jpy");
+$depth = Zaif::pub(PublicApiEndpoint::DEPTH,"mona_jpy");
 
 //出力
 var_dump($price, $depth);
@@ -55,20 +58,20 @@ $secret = "YOUR API SECRET";
 $zaif = new Zaif($key, $secret);
 
 //残高,APIの権限,トレード数,アクティブな注文数,サーバーのタイムスタンプを取得する
-$info = $zaif->trade("get_info");
+$info = $zaif->trade(TradeApiEndpoint::GET_INFO);
 
 //1モナ100円で15モナ売り板に出す
-$trade_ask = $zaif->trade("trade",
-	array(
+$trade_ask = $zaif->trade(TradeApiEndpoint::TRADE,
+	[
 		'currency_pair' => 'mona_jpy',
 		'action' => 'ask',
 		'price' => 100,
 		'amount' => 15 
-	)
+	]
 );
 
 //MONA_JPYの現在有効な注文一覧を表示する
-$active_orders = $zaif->trade("active_orders", array('currency_pair' => 'mona_jpy'));
+$active_orders = $zaif->trade(TradeApiEndpoint::ACTIVE_ORDERS, ['currency_pair' => 'mona_jpy']);
 
 //出力
 var_dump($info, $trade_ask, $active_orders);
@@ -77,7 +80,7 @@ var_dump($info, $trade_ask, $active_orders);
 
 Streaming APIを使うのにAPI Keyを発行する必要はありません。
 ```php
-Zaif::streaming(array('currency_pair' => 'mona_jpy'),function($data){
+Zaif::streaming(['currency_pair' => 'mona_jpy'],function($data){
 	//板の更新や取引が行われる毎に情報を表示
 	var_dump($data);
 });

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ require 'Zaif.php';
 ### 返り値
 JSONがデコードされた状態で値が帰ってきます。
 
-### Public API
+### 現物公開API
 
 Public APIを使うのにAPI Keyを発行する必要はありません。
 ```php
@@ -46,7 +46,7 @@ $depth = Zaif::pub(PublicApiEndpoint::DEPTH,"mona_jpy");
 //出力
 var_dump($price, $depth);
 ```
-### Trade API
+### 現物取引API
 
 Trade APIを使うのにAPI Keyを発行する必要があります。
 https://zaif.jp/api_keys で事前にAPI Keyを発行し、permsのtrade(情報を見る場合はinfoも)を有効にしておいて下さい。
@@ -76,6 +76,34 @@ $active_orders = $zaif->trade(TradeApiEndpoint::ACTIVE_ORDERS, ['currency_pair' 
 //出力
 var_dump($info, $trade_ask, $active_orders);
 ```
+
+### レバレッジ取引API
+
+```php
+
+$key = "YOUR API KEY";
+$secret = "YOUR API SECRET";
+
+//インスタンスの生成
+$zaif = new Zaif($key, $secret);
+
+$price = 720000;
+
+// BTCJPYの2.5倍マージン取引の買いポジションを作成
+$create_position = $zaif->tradeLeverage(TradeLeverageApiEndpoint::CREATE_POSITION, [
+  "type" => "margin",
+  "currency_pair" => "btc_jpy",
+  "action" => "bid",
+  "price" => $price,
+  "amount" => 0.001,
+  "leverage" => 2.5
+]);
+
+// 出力
+var_dump($create_position);
+
+```
+
 ### Streaming API
 
 Streaming APIを使うのにAPI Keyを発行する必要はありません。

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ JSONがデコードされた状態で値が帰ってきます。
 
 ### 現物公開API
 
-Public APIを使うのにAPI Keyを発行する必要はありません。
+現物公開APIを使うのにAPI Keyを発行する必要はありません。
 ```php
 //BTC_JPYの価格を取得する
 $price = Zaif::pub(PublicApiEndpoint::LAST_PRICE,"btc_jpy");
@@ -48,8 +48,8 @@ var_dump($price, $depth);
 ```
 ### 現物取引API
 
-Trade APIを使うのにAPI Keyを発行する必要があります。
-https://zaif.jp/api_keys で事前にAPI Keyを発行し、permsのtrade(情報を見る場合はinfoも)を有効にしておいて下さい。
+現物取引APIを使うのにAPI Keyを発行する必要があります。
+https://zaif.jp/api_keys で事前にAPI Keyを発行し、権限のtrade(情報を見る場合はinfoも)を有効にしておいて下さい。
 ```php
 $key = "YOUR API KEY";
 $secret = "YOUR API SECRET";
@@ -78,6 +78,7 @@ var_dump($info, $trade_ask, $active_orders);
 ```
 
 ### 先物公開API
+先物公開APIを使うのにAPI Keyを発行する必要はありません。
 
 ```php
 // 先物取引の情報を取得します
@@ -88,6 +89,9 @@ var_dump($groups);
 ```
 
 ### レバレッジ取引API
+
+レバレッジ取引APIを使うのにAPI Keyを発行する必要があります。
+https://zaif.jp/api_keys で事前にAPI Keyを発行し、権限のtrade(情報を見る場合はinfoも)を有効にしておいて下さい。
 
 ```php
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ $active_orders = $zaif->trade(TradeApiEndpoint::ACTIVE_ORDERS, ['currency_pair' 
 var_dump($info, $trade_ask, $active_orders);
 ```
 
+### 先物公開API
+
+```php
+// 先物取引の情報を取得します
+$groups = Zaif::publicFutures(PublicFuturesApiEndpoint::GROUPS, [
+    "all"
+]);
+var_dump($groups);
+```
+
 ### レバレッジ取引API
 
 ```php

--- a/Zaif.php
+++ b/Zaif.php
@@ -2,9 +2,45 @@
 
 use WebSocket\Client;
 
+class PublicApiEndpoint
+{
+  const LAST_PRICE = "last_price";
+  const TICKER = "ticker";
+  const TRADES = "trades";
+  const DEPTH = "depth";
+  const CURRENCIES = "currencies";
+  const CURRENCY_PAIRS = "currency_pairs";
+
+  public static function getConstants()
+  {
+    $oClass = new ReflectionClass(__class__);
+    return $oClass->getConstants();
+  }
+}
+
+class TradeApiEndpoint
+{
+  const GET_INFO = "get_info";
+  const GET_INFO2 = "get_info2";
+  const GET_PERSONAL_INFO = "get_personal_info";
+  const GET_ID_INFO = "get_id_info";
+  const TRADE_HISTORY = "trade_history";
+  const ACTIVE_ORDERS = "active_orders";
+  const TRADE = "trade";
+  const CANCEL_ORDER = "cancel_order";
+  const WITHDRAW = "withdraw";
+  const DEPOSIT_HISTORY = "deposit_history";
+  const WITHDRAW_HISTORY = "withdraw_history";
+
+  public static function getConstants()
+  {
+    $oClass = new ReflectionClass(__class__);
+    return $oClass->getConstants();
+  }
+}
+
 class Zaif
 {
-
   const PUBLIC_BASE_URL = "https://api.zaif.jp/api/1";
   const TRADE_BASE_URL = "https://api.zaif.jp/tapi";
   const STREAMING_BASE_URL = "ws://api.zaif.jp:8888/stream";
@@ -22,17 +58,8 @@ class Zaif
 
   public static function pub($endpoint, $prm)
   {
-    switch ($endpoint) {
-      case 'last_price':
-      case 'ticker':
-      case 'trades':
-      case 'depth':
-      case 'currencies':
-      case 'currency_pairs':
-        break;
-      default:
-        throw new Exception('Argument has not been set.');
-        break;
+    if (!in_array($endpoint, array_values(PublicApiEndpoint::getConstants()))) {
+      throw new Exception('Argument has not been set.');
     }
 
     $url = self::PUBLIC_BASE_URL . '/' . $endpoint . '/' . $prm;
@@ -40,26 +67,12 @@ class Zaif
     $data = json_decode($data);
 
     return $data;
-
   }
 
   public function trade($method, $prms = null)
   {
-    switch ($method) {
-      case 'get_info':
-      case 'get_info2':
-      case 'get_personal_info':
-      case 'trade_history':
-      case 'active_orders':
-      case 'trade':
-      case 'cancel_order':
-      case 'withdraw':
-      case 'deposit_history':
-      case 'withdraw_history':
-        break;
-      default:
-        throw new Exception('Argument has not been set.');
-        break;
+    if (!in_array($method, array_values(TradeApiEndpoint::getConstants()))) {
+      throw new Exception('Argument has not been set.');
     }
 
     $postdata = array("nonce" => $this->nonce++, "method" => $method);

--- a/Zaif.php
+++ b/Zaif.php
@@ -33,16 +33,6 @@ class Zaif
         break;
     }
 
-    switch ($prm) {
-      case 'btc_jpy':
-      case 'mona_jpy':
-      case 'mona_btc':
-        break;
-      default:
-        throw new Exception('Argument has not been set.');
-        break;
-    }
-
     $url = self::PUBLIC_BASE_URL . '/' . $endpoint . '/' . $prm;
     $data = self::get($url);
     $data = json_decode($data);
@@ -92,17 +82,6 @@ class Zaif
       require_once $file_path;
     } else {
       throw new Exception('You can not use Streaming API.You should check including libray.');
-    }
-
-    switch ($prms['currency_pair']) {
-      case 'btc_jpy':
-      case 'mona_jpy':
-      case 'mona_btc':
-        break;
-      default:
-        throw new Exception('Argument has not been set.');
-        return 0;
-        break;
     }
 
     $ws = self::STREAMING_BASE_URL . '?' . http_build_query($prms);

--- a/Zaif.php
+++ b/Zaif.php
@@ -2,148 +2,155 @@
 
 use WebSocket\Client;
 
-class Zaif {
+class Zaif
+{
 
-	const PUBLIC_BASE_URL = "https://api.zaif.jp/api/1";
-	const TRADE_BASE_URL = "https://api.zaif.jp/tapi";
-	const STREAMING_BASE_URL = "ws://api.zaif.jp:8888/stream";
+  const PUBLIC_BASE_URL = "https://api.zaif.jp/api/1";
+  const TRADE_BASE_URL = "https://api.zaif.jp/tapi";
+  const STREAMING_BASE_URL = "ws://api.zaif.jp:8888/stream";
 
-	private $key;
-	private $secret;
-	private $nonce;
+  private $key;
+  private $secret;
+  private $nonce;
 
-	public function __construct($key, $secret) {
-		$this->key = $key;
-		$this->secret = $secret;
-		$this->nonce = time();
-	}
-		
-	public static function pub($endpoint, $prm) {
-		switch ($endpoint) {
-			case 'last_price':
-			case 'ticker':
-			case 'trades':
-			case 'depth':
-				break;
-			default:
-				throw new Exception('Argument has not been set.');
-				break;
-		}
+  public function __construct($key, $secret)
+  {
+    $this->key = $key;
+    $this->secret = $secret;
+    $this->nonce = time();
+  }
 
-		switch ($prm) {
-			case 'btc_jpy':
-			case 'mona_jpy':
-			case 'mona_btc':
-				break;
-			default:
-				throw new Exception('Argument has not been set.');
-				break;
-		}
+  public static function pub($endpoint, $prm)
+  {
+    switch ($endpoint) {
+      case 'last_price':
+      case 'ticker':
+      case 'trades':
+      case 'depth':
+        break;
+      default:
+        throw new Exception('Argument has not been set.');
+        break;
+    }
 
-		$url = self::PUBLIC_BASE_URL.'/'.$endpoint.'/'.$prm;
-		$data = self::get($url);
-		$data = json_decode( $data );
+    switch ($prm) {
+      case 'btc_jpy':
+      case 'mona_jpy':
+      case 'mona_btc':
+        break;
+      default:
+        throw new Exception('Argument has not been set.');
+        break;
+    }
 
-		return $data;
+    $url = self::PUBLIC_BASE_URL . '/' . $endpoint . '/' . $prm;
+    $data = self::get($url);
+    $data = json_decode($data);
 
-	}
+    return $data;
 
-	public function trade($method, $prms=null) {
-		switch ($method) {
-			case 'get_info':
-			case 'get_info2':
-			case 'get_personal_info':
-			case 'trade_history':
-			case 'active_orders':
-			case 'trade' :
-			case 'cancel_order' :
-			case 'withdraw' :
-			case 'deposit_history' :
-			case 'withdraw_history' :
-				break;
-			default:
-				throw new Exception('Argument has not been set.');
-				break;
-		}
+  }
 
-		$postdata = array( "nonce" => $this->nonce++, "method" => $method );
-		if( !empty( $prms ) ) {
-			$postdata = array_merge( $postdata, $prms );
-		}
-		$postdata_query = http_build_query( $postdata );
-		$sign = hash_hmac( 'sha512', $postdata_query, $this->secret);
-		$header = array( "Sign: {$sign}", "Key: {$this->key}", );
-		$data = self::post( self::TRADE_BASE_URL, $header, $postdata_query );
-		$data = json_decode( $data );
+  public function trade($method, $prms = null)
+  {
+    switch ($method) {
+      case 'get_info':
+      case 'get_info2':
+      case 'get_personal_info':
+      case 'trade_history':
+      case 'active_orders':
+      case 'trade':
+      case 'cancel_order':
+      case 'withdraw':
+      case 'deposit_history':
+      case 'withdraw_history':
+        break;
+      default:
+        throw new Exception('Argument has not been set.');
+        break;
+    }
 
-		return $data;
-	}
+    $postdata = array("nonce" => $this->nonce++, "method" => $method);
+    if (!empty($prms)) {
+      $postdata = array_merge($postdata, $prms);
+    }
+    $postdata_query = http_build_query($postdata);
+    $sign = hash_hmac('sha512', $postdata_query, $this->secret);
+    $header = array("Sign: {$sign}", "Key: {$this->key}", );
+    $data = self::post(self::TRADE_BASE_URL, $header, $postdata_query);
+    $data = json_decode($data);
 
-	public static function streaming($prms, $callback) {
+    return $data;
+  }
 
-		$file_path = dirname(__FILE__).'/vendor/autoload.php';
+  public static function streaming($prms, $callback)
+  {
 
-		if (file_exists($file_path) && is_readable($file_path)) {
-		    require_once $file_path ;
-		} else {
-			throw new Exception('You can not use Streaming API.You should check including libray.');
-		}
+    $file_path = dirname(__FILE__) . '/vendor/autoload.php';
 
-		switch ($prms['currency_pair']) {
-			case 'btc_jpy':
-			case 'mona_jpy':
-			case 'mona_btc':
-				break;
-			default:
-				throw new Exception('Argument has not been set.');
-				return 0;
-				break;
-		}
+    if (file_exists($file_path) && is_readable($file_path)) {
+      require_once $file_path;
+    } else {
+      throw new Exception('You can not use Streaming API.You should check including libray.');
+    }
 
-		$ws = self::STREAMING_BASE_URL.'?'.http_build_query($prms); 
-		$client = new Client($ws);
+    switch ($prms['currency_pair']) {
+      case 'btc_jpy':
+      case 'mona_jpy':
+      case 'mona_btc':
+        break;
+      default:
+        throw new Exception('Argument has not been set.');
+        return 0;
+        break;
+    }
 
-		while(true) {
-			try {
-				$json = $client->receive();
-				$data = json_decode($json);
-				$callback($data);
-			} catch (WebSocket\ConnectionException $e) {
-				$clinet = new Client($ws);
-			}
-		}
-	}	
+    $ws = self::STREAMING_BASE_URL . '?' . http_build_query($prms);
+    $client = new Client($ws);
 
-	private static function get($url) {
-		$ch = curl_init();
-		$options = array(
-			CURLOPT_URL => $url,
-			CURLOPT_HEADER => false,
-			CURLOPT_RETURNTRANSFER => true,
-			CURLOPT_SSL_VERIFYPEER => false,
-		);
-		curl_setopt_array($ch, $options);
-		$data = curl_exec($ch);
-		curl_close($ch);
+    while (true) {
+      try {
+        $json = $client->receive();
+        $data = json_decode($json);
+        $callback($data);
+      } catch (WebSocket\ConnectionException $e) {
+        $clinet = new Client($ws);
+      }
+    }
+  }
 
-		return $data;
-	}
+  private static function get($url)
+  {
+    $ch = curl_init();
+    $options = array(
+      CURLOPT_URL => $url,
+      CURLOPT_HEADER => false,
+      CURLOPT_RETURNTRANSFER => true,
+      CURLOPT_SSL_VERIFYPEER => false,
+    );
+    curl_setopt_array($ch, $options);
+    $data = curl_exec($ch);
+    curl_close($ch);
 
-	private static function post($url, $header, $postdata) {
-		$ch = curl_init();
-		$options = array(
-			CURLOPT_URL => $url,
-			CURLOPT_HEADER => false,
-			CURLOPT_RETURNTRANSFER => true,
-			CURLOPT_SSL_VERIFYPEER => false,
-			CURLOPT_POST => true,
-			CURLOPT_POSTFIELDS => $postdata,
-			CURLOPT_HTTPHEADER => $header,
-		);
-		curl_setopt_array($ch, $options);
-		$data = curl_exec($ch);
-		curl_close($ch);
+    return $data;
+  }
 
-		return $data;
-	}
+  private static function post($url, $header, $postdata)
+  {
+    $ch = curl_init();
+    $options = array(
+      CURLOPT_URL => $url,
+      CURLOPT_HEADER => false,
+      CURLOPT_RETURNTRANSFER => true,
+      CURLOPT_SSL_VERIFYPEER => false,
+      CURLOPT_POST => true,
+      CURLOPT_POSTFIELDS => $postdata,
+      CURLOPT_HTTPHEADER => $header,
+    );
+    curl_setopt_array($ch, $options);
+    $data = curl_exec($ch);
+    curl_close($ch);
+
+    return $data;
+  }
 }

--- a/Zaif.php
+++ b/Zaif.php
@@ -27,6 +27,8 @@ class Zaif
       case 'ticker':
       case 'trades':
       case 'depth':
+      case 'currencies':
+      case 'currency_pairs':
         break;
       default:
         throw new Exception('Argument has not been set.');

--- a/Zaif.php
+++ b/Zaif.php
@@ -109,15 +109,7 @@ class Zaif
       throw new Exception("Argument has not been set.");
     }
 
-    $postdata = [
-      "nonce" => $this->getNonceWithIncrement(),
-      "method" => $endpoint
-    ];
-
-    if (!empty($prms)) {
-      $postdata = array_merge($postdata, $prms);
-    }
-
+    $postdata = $this->getPostData($endpoint, $prms);
     $postdata_query = http_build_query($postdata);
     $data = CurlWrapper::post(self::TRADE_BASE_URL, $this->getTradeHeader($postdata_query), $postdata_query);
     $data = json_decode($data);
@@ -144,6 +136,15 @@ class Zaif
       throw new Exception("Argument has not been set.");
     }
 
+    $postdata = $this->getPostData($endpoint, $prms);
+    $postdata_query = http_build_query($postdata);
+    $data = CurlWrapper::post(self::TRADE_LEVERAGE_BASE_URL, $this->getTradeHeader($postdata_query), $postdata_query);
+    $data = json_decode($data);
+
+    return $data;
+  }
+
+  private function getPostData($endpoint, $prms) {
     $postdata = [
       "nonce" => $this->getNonceWithIncrement(),
       "method" => $endpoint
@@ -153,11 +154,7 @@ class Zaif
       $postdata = array_merge($postdata, $prms);
     }
 
-    $postdata_query = http_build_query($postdata);
-    $data = CurlWrapper::post(self::TRADE_LEVERAGE_BASE_URL, $this->getTradeHeader($postdata_query), $postdata_query);
-    $data = json_decode($data);
-
-    return $data;
+    return $postdata;
   }
 
   private function getNonceWithIncrement()

--- a/Zaif.php
+++ b/Zaif.php
@@ -39,10 +39,27 @@ class TradeApiEndpoint
   }
 }
 
+class TradeLeverageApiEndpoint
+{
+  const GET_POSITIONS = "get_positions";
+  const POSTION_HISTORY = "position_history";
+  const ACTIVE_POSITIONS = "active_positions";
+  const CREATE_POSITION = "create_position";
+  const CHANGE_POSITION = "change_position";
+  const CANCEL_POSITION = "cancel_position";
+
+  public static function getConstants()
+  {
+    $oClass = new ReflectionClass(__class__);
+    return $oClass->getConstants();
+  }
+}
+
 class Zaif
 {
   const PUBLIC_BASE_URL = "https://api.zaif.jp/api/1";
   const TRADE_BASE_URL = "https://api.zaif.jp/tapi";
+  const TRADE_LEVERAGE_BASE_URL = "https://api.zaif.jp/tlapi";
   const STREAMING_BASE_URL = "ws://api.zaif.jp:8888/stream";
 
   private $key;
@@ -86,6 +103,28 @@ class Zaif
 
     $postdata_query = http_build_query($postdata);
     $data = CurlWrapper::post(self::TRADE_BASE_URL, $this->getTradeHeader($postdata_query), $postdata_query);
+    $data = json_decode($data);
+
+    return $data;
+  }
+
+  public function tradeLeverage($endpoint, $prms = null)
+  {
+    if (!in_array($endpoint, array_values(TradeLeverageApiEndpoint::getConstants()))) {
+      throw new Exception('Argument has not been set.');
+    }
+
+    $postdata = [
+      "nonce" => $this->getNonceWithIncrement(),
+      "method" => $endpoint
+    ];
+
+    if (!empty($prms)) {
+      $postdata = array_merge($postdata, $prms);
+    }
+
+    $postdata_query = http_build_query($postdata);
+    $data = CurlWrapper::post(self::TRADE_LEVERAGE_BASE_URL, $this->getTradeHeader($postdata_query), $postdata_query);
     $data = json_decode($data);
 
     return $data;

--- a/tests/public_api_test.php
+++ b/tests/public_api_test.php
@@ -1,0 +1,57 @@
+<?php
+
+// assertを有効にし、出力を抑制する
+assert_options(ASSERT_ACTIVE, 1);
+assert_options(ASSERT_WARNING, 0);
+assert_options(ASSERT_QUIET_EVAL, 1);
+
+// ハンドラ関数を作成する
+function my_assert_handler($file, $line, $code)
+{
+    var_dump($file, $line, $code);
+    echo "<hr>Assertion Failed:
+        File '$file'<br />
+        Line '$line'<br />
+        Code '$code'<br /><hr />";
+}
+
+// コールバックを設定する
+assert_options(ASSERT_CALLBACK, 'my_assert_handler');
+
+require(__DIR__."/../Zaif.php");
+
+// currencies
+
+$currencies_btc = Zaif::pub(PublicApiEndpoint::CURRENCIES, "btc");
+assert($currencies_btc[0]->name === "btc");
+
+$currencies_all = Zaif::pub(PublicApiEndpoint::CURRENCIES, "all");
+assert(gettype($currencies_all[0]->name) === "string");
+
+// currency_pairs
+
+$currency_pairs_btc_jpy = Zaif::pub(PublicApiEndpoint::CURRENCY_PAIRS, "btc_jpy");
+assert($currency_pairs_btc_jpy[0]->title === "BTC/JPY");
+
+$currency_pairs_btc_all = Zaif::pub(PublicApiEndpoint::CURRENCY_PAIRS, "all");
+assert(gettype($currency_pairs_btc_all[0]->title) === "string");
+
+// last_price
+
+$last_price_btc_jpy = Zaif::pub(PublicApiEndpoint::LAST_PRICE, "btc_jpy");
+assert(gettype($last_price_btc_jpy->last_price) === "double");
+
+// ticker
+
+$ticker_btc_jpy = Zaif::pub(PublicApiEndpoint::TICKER, "btc_jpy");
+assert(gettype($ticker_btc_jpy->last) === "double");
+
+// trades
+
+$trades_btc_jpy = Zaif::pub(PublicApiEndpoint::TRADES, "btc_jpy");
+assert(gettype($trades_btc_jpy[0]->price) === "double");
+
+// depth
+
+$depth_btc_jpy = Zaif::pub(PublicApiEndpoint::DEPTH, "btc_jpy");
+assert(gettype($depth_btc_jpy->asks[0][0]) === "double");

--- a/tests/public_futures_test.php
+++ b/tests/public_futures_test.php
@@ -1,0 +1,68 @@
+<?php
+
+// assertを有効にし、出力を抑制する
+assert_options(ASSERT_ACTIVE, 1);
+assert_options(ASSERT_WARNING, 0);
+assert_options(ASSERT_QUIET_EVAL, 1);
+
+// ハンドラ関数を作成する
+function my_assert_handler($file, $line, $code)
+{
+    var_dump($file, $line, $code);
+    echo "<hr>Assertion Failed:
+        File '$file'<br />
+        Line '$line'<br />
+        Code '$code'<br /><hr />";
+}
+
+// コールバックを設定する
+assert_options(ASSERT_CALLBACK, 'my_assert_handler');
+
+require(__DIR__ . "/../Zaif.php");
+
+// groups
+
+$groups = Zaif::publicFutures(PublicFuturesApiEndpoint::GROUPS, [
+    "all"
+]);
+assert($groups[0]->id === 1);
+
+// last_price
+
+$last_price = Zaif::publicFutures(PublicFuturesApiEndpoint::LAST_PRICE, [
+    1,
+    "btc_jpy"
+]);
+assert(gettype($last_price->last_price) === "double");
+
+// ticker
+
+$ticker = Zaif::publicFutures(PublicFuturesApiEndpoint::TICKER, [
+    1,
+    "btc_jpy"
+]);
+assert(gettype($ticker->last) === "double");
+
+// trades
+
+$trades = Zaif::publicFutures(PublicFuturesApiEndpoint::TRADES, [
+    1,
+    "btc_jpy"
+]);
+assert(gettype($trades[0]->price) === "double");
+
+// depth
+
+$depth = Zaif::publicFutures(PublicFuturesApiEndpoint::DEPTH, [
+    1,
+    "btc_jpy"
+]);
+assert(gettype($depth->asks[0][0]) === "double");
+
+// swap_history
+
+$swap_history = Zaif::publicFutures(PublicFuturesApiEndpoint::GROUPS, [
+    1,
+    "btc_jpy"
+]);
+assert($swap_history[0]->id === 1);

--- a/tests/trade_api_test.php
+++ b/tests/trade_api_test.php
@@ -1,0 +1,98 @@
+<?php
+
+// assertを有効にし、出力を抑制する
+assert_options(ASSERT_ACTIVE, 1);
+assert_options(ASSERT_WARNING, 0);
+assert_options(ASSERT_QUIET_EVAL, 1);
+
+// ハンドラ関数を作成する
+function my_assert_handler($file, $line, $code)
+{
+    var_dump($file, $line, $code);
+    echo "<hr>Assertion Failed:
+        File '$file'<br />
+        Line '$line'<br />
+        Code '$code'<br /><hr />";
+}
+
+// コールバックを設定する
+assert_options(ASSERT_CALLBACK, 'my_assert_handler');
+
+require(__DIR__ . "/../Zaif.php");
+
+$key = getenv("KEY");
+$secret = getenv("SECRET");
+$zaif = new Zaif($key, $secret);
+
+// get_info
+
+$get_info = $zaif->trade(TradeApiEndpoint::GET_INFO);
+assert($get_info->success === 1);
+
+// get_info2
+
+$get_info2 = $zaif->trade(TradeApiEndpoint::GET_INFO2);
+assert($get_info2->success === 1);
+
+// get_personal_info
+
+$get_personal_info = $zaif->trade(TradeApiEndpoint::GET_PERSONAL_INFO);
+assert($get_personal_info->success === 1);
+
+// get_id_info
+
+$get_id_info = $zaif->trade(TradeApiEndpoint::GET_ID_INFO);
+assert($get_personal_info->success === 1);
+
+// trade_history
+
+$trade_history = $zaif->trade(TradeApiEndpoint::TRADE_HISTORY);
+assert($trade_history->success === 1);
+
+// trade_history
+
+$active_orders = $zaif->trade(TradeApiEndpoint::ACTIVE_ORDERS);
+assert($active_orders->success === 1);
+
+
+// trade
+/*
+    注文が確定しない額で注文を入れ、その後キャンセルする
+ */
+
+$last_price = Zaif::pub(PublicApiEndpoint::LAST_PRICE, "btc_jpy");
+$trade_btc_jpy_price = ceil($last_price->last_price * 0.6 / 10) * 10;
+$trade = $zaif->trade(TradeApiEndpoint::TRADE, [
+    "currency_pair" => "btc_jpy",
+    "action" => "bid",
+    "price" => $trade_btc_jpy_price,
+    "amount" => 0.001
+]);
+assert($trade->success === 1);
+
+sleep(5);
+
+// cancel_order
+
+$cancel_order = $zaif->trade(TradeApiEndpoint::CANCEL_ORDER, [
+    "order_id" => $trade->return->order_id
+]);
+assert($cancel_order->success === 1);
+
+// withdraw テスト未サポート
+
+// deposit_history
+
+$deposit_history = $zaif->trade(TradeApiEndpoint::DEPOSIT_HISTORY, [
+    "currency" => "jpy"
+]);
+
+assert($deposit_history->success === 1);
+
+// withdraw_history
+
+$deposit_history = $zaif->trade(TradeApiEndpoint::WITHDRAW_HISTORY, [
+    "currency" => "jpy"
+]);
+
+assert($deposit_history->success === 1);

--- a/tests/trade_leverage_api_test.php
+++ b/tests/trade_leverage_api_test.php
@@ -1,0 +1,88 @@
+<?php
+
+// assertを有効にし、出力を抑制する
+assert_options(ASSERT_ACTIVE, 1);
+assert_options(ASSERT_WARNING, 0);
+assert_options(ASSERT_QUIET_EVAL, 1);
+
+// ハンドラ関数を作成する
+function my_assert_handler($file, $line, $code)
+{
+    var_dump($file, $line, $code);
+    echo "<hr>Assertion Failed:
+        File '$file'<br />
+        Line '$line'<br />
+        Code '$code'<br /><hr />";
+}
+
+// コールバックを設定する
+assert_options(ASSERT_CALLBACK, 'my_assert_handler');
+
+require(__DIR__ . "/../Zaif.php");
+
+$key = getenv("KEY");
+$secret = getenv("SECRET");
+$zaif = new Zaif($key, $secret);
+
+// get_positions
+
+$get_positions = $zaif->tradeLeverage(TradeLeverageApiEndpoint::GET_POSITIONS, [
+    "type" => "margin",
+    "count" => 1
+]);
+assert($get_positions->success === 1);
+
+// get_positions
+
+$position_history = $zaif->tradeLeverage(TradeLeverageApiEndpoint::POSTION_HISTORY, [
+    "type" => "margin",
+    "leverage_id" => 1982406
+]);
+assert($position_history->success === 1);
+
+// get_positions
+
+$active_positions = $zaif->tradeLeverage(TradeLeverageApiEndpoint::ACTIVE_POSITIONS, [
+    "type" => "margin"
+]);
+assert($active_positions->success === 1);
+
+// 取引のテストをする場合は自分で価格を設定し、実行してください
+if (false) {
+    $price = 720000;
+
+    // create_position
+
+    $create_position = $zaif->tradeLeverage(TradeLeverageApiEndpoint::CREATE_POSITION, [
+        "type" => "margin",
+        "currency_pair" => "btc_jpy",
+        "action" => "bid",
+        "price" => $price,
+        "amount" => 0.001,
+        "leverage" => 2.5
+    ]);
+    assert($create_position->success === 1);
+
+    sleep(5);
+
+    // change_position
+
+    $change_position = $zaif->tradeLeverage(TradeLeverageApiEndpoint::CHANGE_POSITION, [
+        "type" => "margin",
+        "leverage_id" => $create_position->return->leverage_id,
+        "price" => $price + 5
+    ]);
+
+    assert($change_position->success === 1);
+
+    sleep(5);
+
+    // cancel_position
+
+    $change_position = $zaif->tradeLeverage(TradeLeverageApiEndpoint::CANCEL_POSITION, [
+        "type" => "margin",
+        "leverage_id" => $create_position->return->leverage_id
+    ]);
+
+    assert($change_position->success === 1);
+}


### PR DESCRIPTION
- 検証していませんが互換性はあると思います
- PHP7.2の環境で開発しているのでPHP7.2以降が推奨環境です

## 変更点
- 通貨ペアのチェックを削除したのでどの通貨でも取引可能になりました
- 信用取引のサポート

## タスク
- [x] 先物公開APIのサポート
- [x] 信用取引方法のドキュメント追加

## 関連
https://github.com/tk1024/Zaif4PHP/issues/7
https://github.com/tk1024/Zaif4PHP/issues/3